### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/OrderManager/OrderManager.csproj
+++ b/OrderManager/OrderManager.csproj
@@ -4,11 +4,11 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.6.2" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="1.8.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi@massimobonanni, I found an issue in the OrderManager.csproj:

Packages Microsoft.Azure.WebJobs.Extensions.DurableTask v1.6.2, Microsoft.Azure.WebJobs.Extensions.SendGrid v3.0.0, Microsoft.Azure.WebJobs.Extensions.Storage v3.0.0, Microsoft.Extensions.Logging.Abstractions v2.1.1 and Microsoft.NET.Sdk.Functions v3.0.3 transitively introduce 124 dependencies into OrderManagerServerless’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/OrderManagerServerless.html)), while Microsoft.Azure.WebJobs.Extensions.DurableTask v1.8.3, Microsoft.Azure.WebJobs.Extensions.SendGrid v3.0.2, Microsoft.Azure.WebJobs.Extensions.Storage v3.0.2, Microsoft.Extensions.Logging.Abstractions v2.2.0 and Microsoft.NET.Sdk.Functions v3.0.6 can only introduce 93 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/OrderManagerServerless_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose